### PR TITLE
Make docker-compose implementation agnostic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-db.env
+*.env

--- a/README.md
+++ b/README.md
@@ -253,6 +253,23 @@ Forward both ports `80` and `443` to your Raspberry Pi.
 
 ## Set Environment Variables
 
+### Generic Environment Variables
+
+Create a .env file in the same directory as your docker-compose.yml file
+
+```bash
+$ nano general.env
+```
+
+Add the following environment variables
+
+```ini
+EMAIL=$your_email$
+URL=$main_domain$  # eg: austinmcconnell.me
+```
+
+### Database-Specific Environment Variables
+
 Create a db.env file in the same directory as your docker-compose.yml file
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,13 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - EMAIL=austin.s.mcconnell@gmail.com
-      - URL=austinmcconnell.me
       - SUBDOMAINS=pi,nextcloud,plex,automation
       - ONLY_SUBDOMAINS=true
       - DHLEVEL=2048
       - VALIDATION=http
       - TZ=America/Chicago
+    env_file:
+      - general.env
   plex:
     image: lsioarmhf/plex
     container_name: plex


### PR DESCRIPTION
Move implementation-specific details (i.e. EMAIL and URL) into general.env file

Closes #1